### PR TITLE
Explicitly fire extractor on text/plain and text/file. Don't use wild…

### DIFF
--- a/src/clowder_extractors/parameter_extractor/extractor_info.json
+++ b/src/clowder_extractors/parameter_extractor/extractor_info.json
@@ -18,7 +18,8 @@
   ],
   "process": {
     "file": [
-      "text/*"
+      "text/file",
+      "text/plain"
     ]
   },
   "external_services": [],


### PR DESCRIPTION
…card since it can trigger for csv file