### PR TITLE
Fix none divided by float error 

### DIFF
--- a/src/clowder_extractors/experiment_from_excel/remat_experiment_from_excel.py
+++ b/src/clowder_extractors/experiment_from_excel/remat_experiment_from_excel.py
@@ -195,7 +195,7 @@ def compute_values(inputs: dict, inputs_procedure: dict):
                 measured_mass * 1000.0
             )  # to display in meta-data for measured mass
 
-        elif "Measured mass (mg)" in compound:
+        elif compound.get("Measured mass (mg)", None):
             measured_mass = compound["Measured mass (mg)"] / 1000.0
             compound["Measured mass (g)"] = measured_mass
         else:


### PR DESCRIPTION
When the solvent quantity is provided in volume instead of mass we generate an exception:
```
2025-07-06 01:05:39,226 [Thread-2048 (_process_message)] ERROR   : pyclowder.connectors - [6869c748e4b004200220c3c0] unsupported operand type(s) for /: 'NoneType' and 'float'
```

Fix this by checking to see if the mass is not none